### PR TITLE
feat: split bill

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -184,10 +184,37 @@ def broadcast(message: Message):
 
     bot.reply_to(message, f"Broadcast completed. Successfully sent to {success_count} out of {len(chat_ids)} chats.")
 
+@bot.message_handler(content_types=['photo'])
+def handle_messages(message: Message):
+    logger.info("message contains photo and caption is: [%s]", message.caption)
+
+    if message.caption is None:
+        logger.debug("skipping photo with no caption")
+        return
+
+    parts = message.caption.split(' ', 1)
+    if parts[0] == 'split_bill' or parts[0] == 'sb':
+        raw = message.photo[-1].file_id
+        file_info = bot.get_file(raw)
+        photo_bytes = bot.download_file(file_info.file_path)
+
+        description = ""
+        if len(parts) > 1:
+            description = parts[1]
+
+        split_bill_result = brain.split_bill(photo_bytes, description)
+
+        logger.info("received analysis result: [%s]", split_bill_result)
+        bot.reply_to(message, str(split_bill_result))
+
+        return
+
+
 @bot.message_handler(func=lambda message: True)
 def handle_messages(message: Message):
     logger.debug("adding message to db: [%s]", message.text)
     db.store_message(message)
+
 
 def start():
     logger.info("starting webhook with url: [%s] + [%s]", WEBHOOK_HOST, WEBHOOK_URL_PATH)

--- a/src/brain.py
+++ b/src/brain.py
@@ -30,13 +30,12 @@ def get_answer_to_question(discussion, question) -> str:
 
     return use_brain(prompt)
 
-def use_brain(prompt, photo_bytes=None) -> str:
+def use_brain(prompt) -> str:
     try:
         response = anthropic.completions.create(
             model="claude-2",
             prompt=prompt,
             max_tokens_to_sample=600,
-            photo_bytes=photo_bytes,
         )
         return response.completion
     except Exception as e:

--- a/src/brain.py
+++ b/src/brain.py
@@ -1,6 +1,7 @@
 import os
 from anthropic import Anthropic, HUMAN_PROMPT, AI_PROMPT
 import utils.logging as logging
+import base64
 
 logger = logging.GetLogger()
 
@@ -9,6 +10,7 @@ anthropic = Anthropic(api_key=ANTHROPIC_API_KEY)
 
 SUMMARY_REQUEST = "can you summarize briefly this discussion for me? Answer in the language the messages were sent\n"
 QUESTION_REQUEST = "can you answer this question for me based on the discussion I will prove you? Answer in the language the messages were sent\n Here's the discussion: "
+SPLIT_BILL_REQUEST = "can you split the bill for me based on the description and the photo? Any item that is not listed will be split equally. Add a 'Final totals' section at the very end to show the total amount each person owes. \n Here's the photo and the description: "
 
 def get_generic_response(request) -> str:
     prompt = f"{HUMAN_PROMPT}" + request + f"{AI_PROMPT}"
@@ -28,13 +30,47 @@ def get_answer_to_question(discussion, question) -> str:
 
     return use_brain(prompt)
 
-def use_brain(prompt) -> str:
+def use_brain(prompt, photo_bytes=None) -> str:
     try:
         response = anthropic.completions.create(
             model="claude-2",
             prompt=prompt,
             max_tokens_to_sample=600,
+            photo_bytes=photo_bytes,
         )
         return response.completion
     except Exception as e:
         return f"Error generating AI summary: {str(e)}"
+
+def split_bill(photo_bytes: str, description: str) -> str:
+    try:
+        base64_image = base64.b64encode(photo_bytes).decode('utf-8')
+
+        response = anthropic.messages.create(
+            model="claude-3-5-sonnet-20240620",
+            max_tokens=1000,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/jpeg",
+                                "data": base64_image
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "text": f"{SPLIT_BILL_REQUEST}\n\nDescription: {description}"
+                        }
+                    ]
+                }
+            ]
+        )
+
+        return response.content[0].text
+    except Exception as e:
+        logger.error("Error processing bill: %s", str(e))
+        return f"Error processing bill: {str(e)}"


### PR DESCRIPTION
# Add Bill Splitting Feature

## Overview
This PR introduces a new bill splitting feature that allows users to upload a photo of a receipt and get an AI-powered analysis of how to split the bill among participants.

## Changes
- Added new bill splitting functionality in `brain.py` using Claude 3.5 Sonnet model
- Implemented photo handling and processing in `bot.py`
- Added support for base64 image encoding and processing
- Integrated with Anthropic's latest Claude 3.5 Sonnet model for better image analysis

## Technical Details
- Uses Claude 3.5 Sonnet (20240620) model for image analysis
- Supports both image and text input for bill splitting
- Handles base64 image encoding for API compatibility
- Includes error handling and logging for the bill splitting process

## Usage
Users can now split bills by sending a photo with the caption:
- `split_bill` or `sb` followed by an optional description
- The bot will analyze the receipt and provide a detailed breakdown of how to split the bill
- Any items not specifically listed will be split equally among participants
- The response includes a "Final totals" section showing what each person owes

## Testing
- Tested with various receipt formats and descriptions
- Verified error handling for invalid inputs
- Confirmed proper image processing and base64 encoding

## Dependencies
- Requires Anthropic API key with access to Claude 3.5 Sonnet
- Uses base64 encoding for image processing